### PR TITLE
firejail per-game "whitelist" (via noblacklist)

### DIFF
--- a/runner/firejail_linux.go
+++ b/runner/firejail_linux.go
@@ -4,10 +4,10 @@ package runner
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"text/template"
 
 	"github.com/itchio/smaug/runner/policies"
 	"github.com/pkg/errors"
@@ -48,9 +48,18 @@ func (fr *firejailRunner) Run() error {
 	if err != nil {
 		return errors.WithStack(err)
 	}
-
-	sandboxSource := policies.FirejailTemplate
-	err = ioutil.WriteFile(sandboxProfilePath, []byte(sandboxSource), 0644)
+	
+	sandboxTemplate, err := template.New("firejail-profile").Parse(policies.FirejailTemplate)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	
+	sandboxFile, err := os.OpenFile(sandboxProfilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	
+	err = sandboxTemplate.Execute(sandboxFile, params)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/runner/policies/firejail.go
+++ b/runner/policies/firejail.go
@@ -7,17 +7,20 @@ package policies
 // whitelist doesn't seem to work with exclusions, though?
 
 const FirejailTemplate = `
-blacklist ~/.config/itch/users
-blacklist ~/.config/itch/butler_creds
-blacklist ~/.config/itch/marketdb
-blacklist ~/.config/itch/Cookies
-blacklist ~/.config/itch/Partitions
+include /etc/firejail/itch_game_{{.Name}}.local
+include /etc/firejail/itch_games_globals.local
 
-blacklist ~/.config/kitch/users
-blacklist ~/.config/kitch/butler_creds
-blacklist ~/.config/kitch/marketdb
-blacklist ~/.config/kitch/Cookies
-blacklist ~/.config/kitch/Partitions
+noblacklist {{.FullTargetPath}}
+noblacklist {{.InstallFolder}}
+blacklist {{.InstallFolder}}/.itch
+
+noblacklist ${HOME}/.config/itch/apps
+blacklist   ${HOME}/.config/itch/*
+blacklist   ${HOME}/.config/itch/apps/*
+
+noblacklist ${HOME}/.config/kitch/apps
+blacklist   ${HOME}/.config/kitch/*
+blacklist   ${HOME}/.config/kitch/apps/*
 
 blacklist ~/.config/chromium
 blacklist ~/.config/chrome


### PR DESCRIPTION
Instead of blacklisting individual sensitive itch app/kitch directories (enumerating badness), blacklist all  itch app subdirectories and all other games, except for the current game.

To enable this, the firejail policy template is now a text/template, not only a fixed string.